### PR TITLE
表示切り替え機能追加

### DIFF
--- a/src/app/library/library/library.component.html
+++ b/src/app/library/library/library.component.html
@@ -1,6 +1,48 @@
 <div class="container">
-  <div class="grid">
-    <div *ngFor="let book of books$ | async">
+  <div class="header-nav">
+    <input
+      appearance="outline"
+      placeholder="ライブラリ内検索"
+      class="header-nav__search"
+      type="text"
+    />
+    <button
+      class="header-nav__sort"
+      mat-flat-button
+      [matMenuTriggerFor]="sortMenu"
+    >
+      並び替え
+    </button>
+    <button
+      class="header-nav__grid"
+      *ngIf="!isGrid"
+      mat-icon-button
+      (click)="isGrid = !isGrid"
+    >
+      <mat-icon>apps</mat-icon>グリッド
+    </button>
+    <button
+      class="header-nav__list"
+      *ngIf="isGrid"
+      mat-icon-button
+      (click)="isGrid = !isGrid"
+    >
+      <mat-icon>format_list_bulleted</mat-icon>リスト
+    </button>
+    <mat-menu class="menu" #sortMenu="matMenu">
+      <button mat-menu-item>
+        <span>追加日</span>
+      </button>
+      <button mat-menu-item>
+        <span>タイトル</span>
+      </button>
+      <button mat-menu-item>
+        <span>著者</span>
+      </button>
+    </mat-menu>
+  </div>
+  <div class="grid" *ngIf="isGrid; else isList">
+    <ng-container *ngFor="let book of books$ | async">
       <li class="book">
         <img
           [src]="book.volumeInfo.imageLinks.smallThumbnail"
@@ -21,6 +63,36 @@
           </button>
         </mat-menu>
       </li>
-    </div>
+    </ng-container>
   </div>
+  <ng-template #isList>
+    <div class="list">
+      <ng-container *ngFor="let book of books$ | async">
+        <li class="book">
+          <img
+            [src]="book.volumeInfo.imageLinks.thumbnail"
+            [alt]="book.volumeInfo.title"
+            [routerLink]="['/review', book.id]"
+          />
+          <div class="book__body">
+            <p class="book__title">{{ book.volumeInfo.title }}</p>
+            <p class="book__authors">{{ book.volumeInfo.authors }}</p>
+          </div>
+          <button
+            class="book__remove"
+            mat-icon-button
+            [matMenuTriggerFor]="removeMenu"
+          >
+            <mat-icon>more_vert</mat-icon>
+          </button>
+          <mat-menu class="menu" #removeMenu="matMenu">
+            <button mat-menu-item (click)="openRemoveDialog(book)">
+              <mat-icon>delete</mat-icon>
+              <span>削除</span>
+            </button>
+          </mat-menu>
+        </li>
+      </ng-container>
+    </div>
+  </ng-template>
 </div>

--- a/src/app/library/library/library.component.html
+++ b/src/app/library/library/library.component.html
@@ -43,20 +43,20 @@
   </div>
   <div class="grid" *ngIf="isGrid; else isList">
     <ng-container *ngFor="let book of books$ | async">
-      <li class="book">
+      <li class="grid--book">
         <img
           [src]="book.volumeInfo.imageLinks.smallThumbnail"
           [alt]="book.volumeInfo.title"
           [routerLink]="['/review', book.id]"
         />
         <button
-          class="book__remove"
+          class="grid--book__remove"
           mat-icon-button
           [matMenuTriggerFor]="removeMenu"
         >
           <mat-icon>more_vert</mat-icon>
         </button>
-        <mat-menu class="menu" #removeMenu="matMenu">
+        <mat-menu #removeMenu="matMenu">
           <button mat-menu-item (click)="openRemoveDialog(book)">
             <mat-icon>delete</mat-icon>
             <span>削除</span>
@@ -68,24 +68,24 @@
   <ng-template #isList>
     <div class="list">
       <ng-container *ngFor="let book of books$ | async">
-        <li class="book">
+        <li class="list--book">
           <img
             [src]="book.volumeInfo.imageLinks.thumbnail"
             [alt]="book.volumeInfo.title"
             [routerLink]="['/review', book.id]"
           />
-          <div class="book__body">
-            <p class="book__title">{{ book.volumeInfo.title }}</p>
-            <p class="book__authors">{{ book.volumeInfo.authors }}</p>
+          <div class="list--book__body">
+            <p class="list--book__title">{{ book.volumeInfo.title }}</p>
+            <p class="list--book__authors">{{ book.volumeInfo.authors }}</p>
           </div>
           <button
-            class="book__remove"
+            class="list--book__remove"
             mat-icon-button
             [matMenuTriggerFor]="removeMenu"
           >
             <mat-icon>more_vert</mat-icon>
           </button>
-          <mat-menu class="menu" #removeMenu="matMenu">
+          <mat-menu #removeMenu="matMenu">
             <button mat-menu-item (click)="openRemoveDialog(book)">
               <mat-icon>delete</mat-icon>
               <span>削除</span>

--- a/src/app/library/library/library.component.html
+++ b/src/app/library/library/library.component.html
@@ -1,10 +1,11 @@
 <div class="container">
   <div class="grid">
     <div *ngFor="let book of books$ | async">
-      <li class="book" [routerLink]="['/review', book.id]">
+      <li class="book">
         <img
           [src]="book.volumeInfo.imageLinks.smallThumbnail"
           [alt]="book.volumeInfo.title"
+          [routerLink]="['/review', book.id]"
         />
         <button
           class="book__remove"

--- a/src/app/library/library/library.component.html
+++ b/src/app/library/library/library.component.html
@@ -43,14 +43,14 @@
   </div>
   <div class="grid" *ngIf="isGrid; else isList">
     <ng-container *ngFor="let book of books$ | async">
-      <li class="grid--book">
+      <li class="grid-book">
         <img
           [src]="book.volumeInfo.imageLinks.smallThumbnail"
           [alt]="book.volumeInfo.title"
           [routerLink]="['/review', book.id]"
         />
         <button
-          class="grid--book__remove"
+          class="grid-book__remove"
           mat-icon-button
           [matMenuTriggerFor]="removeMenu"
         >
@@ -66,17 +66,17 @@
     </ng-container>
   </div>
   <ng-template #isList>
-    <div class="list">
+    <div>
       <ng-container *ngFor="let book of books$ | async">
-        <li class="list--book">
+        <li class="list-book">
           <img
             [src]="book.volumeInfo.imageLinks.thumbnail"
             [alt]="book.volumeInfo.title"
             [routerLink]="['/review', book.id]"
           />
-          <div class="list--book__body">
-            <p class="list--book__title">{{ book.volumeInfo.title }}</p>
-            <p class="list--book__authors">{{ book.volumeInfo.authors }}</p>
+          <div class="list-book__body">
+            <p class="list-book__title">{{ book.volumeInfo.title }}</p>
+            <p class="list-book__authors">{{ book.volumeInfo.authors }}</p>
           </div>
           <button
             class="list--book__remove"

--- a/src/app/library/library/library.component.scss
+++ b/src/app/library/library/library.component.scss
@@ -30,31 +30,30 @@ img {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
   gap: 24px;
-  &--book {
-    list-style: none;
-    position: relative;
-    width: 100%;
-    min-height: 120px;
-    height: 100%;
-    object-fit: cover;
-    background: #ddd;
-    &__remove {
-      position: absolute;
-      top: 0;
-      right: 0;
-      background-color: rgba(145, 145, 145, 0.5);
-    }
+}
+
+.grid-book {
+  list-style: none;
+  position: relative;
+  width: 100%;
+  min-height: 120px;
+  height: 100%;
+  object-fit: cover;
+  background: #ddd;
+  &__remove {
+    position: absolute;
+    top: 0;
+    right: 0;
+    background-color: rgba(145, 145, 145, 0.5);
   }
 }
 
-.list {
-  &--book {
-    list-style: none;
-    padding: 8px;
-    display: grid;
-    gap: 16;
-    grid-template-columns: 80px 1fr 40px;
-  }
+.list-book {
+  list-style: none;
+  padding: 8px;
+  display: grid;
+  gap: 16;
+  grid-template-columns: 80px 1fr 40px;
 }
 
 @media screen and (max-width: 470px) {

--- a/src/app/library/library/library.component.scss
+++ b/src/app/library/library/library.component.scss
@@ -3,37 +3,64 @@
   padding: 16px;
 }
 
+.header-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+  padding-right: 24px;
+  &__sort {
+    line-height: 1;
+  }
+  &__grid {
+    line-height: 1;
+  }
+  &__list {
+    line-height: 1;
+  }
+}
+
+img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  outline: none;
+}
+
 .grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
   gap: 24px;
-}
 
-.book {
-  list-style: none;
-  position: relative;
-  width: 100%;
-  min-height: 120px;
-  height: 100%;
-  object-fit: cover;
-  background: #ddd;
-  &__remove {
-    position: absolute;
-    top: 0;
-    right: 0;
-    background-color: rgba(145, 145, 145, 0.5);
-  }
-  img {
+  .book {
+    list-style: none;
+    position: relative;
     width: 100%;
+    min-height: 120px;
     height: 100%;
     object-fit: cover;
-    outline: none;
+    background: #ddd;
+    &__remove {
+      position: absolute;
+      top: 0;
+      right: 0;
+      background-color: rgba(145, 145, 145, 0.5);
+    }
+  }
+
+  .mat-menu-item {
+    .mat-icon {
+      margin-right: 8px;
+    }
   }
 }
 
-.mat-menu-item {
-  .mat-icon {
-    margin-right: 8px;
+.list {
+  .book {
+    list-style: none;
+    padding: 8px;
+    display: grid;
+    gap: 16;
+    grid-template-columns: 80px 1fr 40px;
   }
 }
 

--- a/src/app/library/library/library.component.scss
+++ b/src/app/library/library/library.component.scss
@@ -19,7 +19,6 @@
   background: #ddd;
   &__remove {
     position: absolute;
-    z-index: 10;
     top: 0;
     right: 0;
     background-color: rgba(145, 145, 145, 0.5);
@@ -28,6 +27,7 @@
     width: 100%;
     height: 100%;
     object-fit: cover;
+    outline: none;
   }
 }
 

--- a/src/app/library/library/library.component.scss
+++ b/src/app/library/library/library.component.scss
@@ -30,8 +30,7 @@ img {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
   gap: 24px;
-
-  .book {
+  &--book {
     list-style: none;
     position: relative;
     width: 100%;
@@ -46,16 +45,10 @@ img {
       background-color: rgba(145, 145, 145, 0.5);
     }
   }
-
-  .mat-menu-item {
-    .mat-icon {
-      margin-right: 8px;
-    }
-  }
 }
 
 .list {
-  .book {
+  &--book {
     list-style: none;
     padding: 8px;
     display: grid;

--- a/src/app/library/library/library.component.ts
+++ b/src/app/library/library/library.component.ts
@@ -12,6 +12,7 @@ import { RemoveDialogComponent } from '../remove-dialog/remove-dialog.component'
 })
 export class LibraryComponent implements OnInit {
   books$: Observable<Book[]> = this.databaseBooks.getToFavoriteBooks();
+  isGrid = true;
 
   constructor(
     private databaseBooks: DatabaseBooksService,


### PR DESCRIPTION
![toggle](https://user-images.githubusercontent.com/57104153/88077901-c488af80-cbb6-11ea-8507-04034ea0e0f6.gif)

## やったこと
- リスト表示用のhtml,css作成
- リスト表示とグリッド表示の切替機能追加
- ソートバー作成（リスト表示とグリッド表示以外は見た目だけ）
- liタグからimgタグに`[routerLink]`を移動（サムネイル右上のiconをクリックできないエラーが出ていたため）

## 次やること
- ソートバーとサムネイル表示画面のコンポネントを分ける
- ソート機能(追加日、タイトル、著者)
- 見た目の仕上げ
- テキスト検索は実装するか検討中