### PR TITLE
動的フォームの追加時のExpressionChangedAfterItHasBeenCheckedError修正

### DIFF
--- a/src/app/review/review-form/review-form.component.ts
+++ b/src/app/review/review-form/review-form.component.ts
@@ -13,7 +13,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
   styleUrls: ['./review-form.component.scss'],
 })
 export class ReviewFormComponent implements OnInit {
-  showInput = false;
+  showInput: boolean;
   @Input() book: Book;
 
   selectedQuestion = [];

--- a/src/app/review/review-form/review-form.component.ts
+++ b/src/app/review/review-form/review-form.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, OnInit, Input, ChangeDetectorRef } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { questionsList } from './questions-list';
 import { Book } from 'src/app/interface/book';
@@ -28,7 +28,8 @@ export class ReviewFormComponent implements OnInit {
     public dialog: MatDialog,
     private fb: FormBuilder,
     private snackBer: MatSnackBar,
-    public databaseReviewService: DatabaseReviewsService
+    public databaseReviewService: DatabaseReviewsService,
+    private cd: ChangeDetectorRef
   ) {}
 
   get answers(): FormArray {
@@ -54,6 +55,7 @@ export class ReviewFormComponent implements OnInit {
       this.snackBer.open('その質問は既にあります');
     }
     this.showInput = true;
+    this.cd.detectChanges();
   }
 
   removeAnswer(index: number) {


### PR DESCRIPTION
#102 
![image](https://user-images.githubusercontent.com/57104153/96346482-ff778200-10d6-11eb-806c-b6e48d6b7844.png)

npmパッケージのauto focusの実装のためにformのfocusを監視しているため、質問を選択ボタンでformを追加した時にエラー
```error
ExpressionChangedAfterItHasBeenCheckedError: 
Expression has changed after it was checked. Previous value: 'false'. Current value: 'true'.
```
が出ていたのを修正しました。