### PR TITLE
fix(reviewService): interface追加文をomitに追加

### DIFF
--- a/src/app/services/database-reviews.service.ts
+++ b/src/app/services/database-reviews.service.ts
@@ -83,7 +83,16 @@ export class DatabaseReviewsService {
 
   updateReview(
     book: Book,
-    review: Omit<Review, 'createdDate' | 'createdAt' | 'title' | 'question'>
+    review: Omit<
+      Review,
+      | 'createdDate'
+      | 'createdAt'
+      | 'title'
+      | 'question'
+      | 'uid'
+      | 'bookId'
+      | 'thumbnail'
+    >
   ) {
     return this.db
       .doc(


### PR DESCRIPTION
前回PR出した時にrevewインターフェースに 'uid','bookId', 'thumbnail'を追加していたのですが、その分をcreateReview()のomitには追加していたのですが、updateReview()のomitに追加し忘れていました。
前回PRのmergeを取り込んだ際にエラーが発生したことで気づきました。
すみません。