### PR TITLE
fix(GithubActions): firestore.indexesにindex追加

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -2,6 +2,20 @@
   "indexes": [
     {
       "collectionGroup": "reviews",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        {
+          "fieldPath": "uid",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
         {
@@ -29,5 +43,28 @@
       ]
     }
   ],
-  "fieldOverrides": []
+  "fieldOverrides": [
+    {
+      "collectionGroup": "reviews",
+      "fieldPath": "uid",
+      "indexes": [
+        {
+          "order": "ASCENDING",
+          "queryScope": "COLLECTION"
+        },
+        {
+          "order": "DESCENDING",
+          "queryScope": "COLLECTION"
+        },
+        {
+          "arrayConfig": "CONTAINS",
+          "queryScope": "COLLECTION"
+        },
+        {
+          "order": "ASCENDING",
+          "queryScope": "COLLECTION_GROUP"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## エラー内容
```
プロジェクトで定義されているインデックスが1つあり、firestore indexesファイルには存在しません。これらを削除するには、次のコマンドを --force フラグをつけて実行してください。
```
## 対応内容
必要なindexなので
```js
firebase firestore:indexes > firestore.indexes.json
```
でindexを追加しました。