### PR TITLE
GithubActionsError: ERROR in Exceeded maximum budget の対応をしました

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -54,8 +54,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "6kb",
-                  "maximumError": "10kb"
+                  "maximumWarning": "60kb",
+                  "maximumError": "100kb"
                 }
               ]
             }


### PR DESCRIPTION
#129 
## エラー内容
```js
ERROR in Exceeded maximum budget for /home/runner/work/diary-for-reader/diary-for-reader/src/app/shered/delete-user-dialog/delete-user-dialog.component.scss. Budget 10 kB was not met by 4.05 kB with a total of 14.1 kB.
ERROR in Exceeded maximum budget for /home/runner/work/diary-for-reader/diary-for-reader/src/app/add-books/search-books/search-books.component.scss. Budget 10 kB was not met by 4.06 kB with a total of 14.1 kB.
ERROR in Exceeded maximum budget for /home/runner/work/diary-for-reader/diary-for-reader/src/app/bottom-nav/bottom-nav.component.scss. Budget 10 kB was not met by 4 kB with a total of 14 kB.
ERROR in Exceeded maximum budget for /home/runner/work/diary-for-reader/diary-for-reader/src/app/side-nav/side-nav.component.scss. Budget 10 kB was not met by 4.04 kB with a total of 14 kB.
ERROR in Exceeded maximum budget for /home/runner/work/diary-for-reader/diary-for-reader/src/app/library/library/library.component.scss. Budget 10 kB was not met by 4.68 kB with a total of 14.7 kB.
ERROR in Exceeded maximum budget for /home/runner/work/diary-for-reader/diary-for-reader/src/app/library/library-search/library-search.component.scss. Budget 10 kB was not met by 4.53 kB with a total of 14.5 kB.
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! diary-for-reader@0.0.0 build: `ng build --prod`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the diary-for-reader@0.0.0 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/runner/.npm/_logs/2021-01-06T01_06_27_551Z-debug.log
Error: Process completed with exit code 1.
```
## 対応処理
angular.jsonの中の"maximumError" の上限を上げました。

以上、確認お願いします。