### PR TITLE
fix(settings): settings画面マークアップ、機能修正完了

### DIFF
--- a/src/app/shered/delete-user-dialog/delete-user-dialog.component.html
+++ b/src/app/shered/delete-user-dialog/delete-user-dialog.component.html
@@ -9,6 +9,8 @@
   <form class="form">
     <input class="form__input" type="text" [formControl]="form" />
     <button
+      (click)="deleteUser()"
+      mat-dialog-close
       class="form__btn"
       mat-flat-button
       color="primary"

--- a/src/app/shered/delete-user-dialog/delete-user-dialog.component.scss
+++ b/src/app/shered/delete-user-dialog/delete-user-dialog.component.scss
@@ -10,7 +10,7 @@
 }
 .attention {
   font-size: 14px;
-  color: rgb(253, 176, 76);
+  color: rgb(240, 136, 0);
   margin-bottom: 16px;
 }
 .form {

--- a/src/app/shered/delete-user-dialog/delete-user-dialog.component.ts
+++ b/src/app/shered/delete-user-dialog/delete-user-dialog.component.ts
@@ -1,5 +1,6 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { FormControl } from '@angular/forms';
+import { UserService } from 'src/app/services/user.service';
 
 @Component({
   selector: 'app-delete-user-dialog',
@@ -8,7 +9,11 @@ import { FormControl } from '@angular/forms';
 })
 export class DeleteUserDialogComponent implements OnInit {
   form = new FormControl('');
-  constructor() {}
+  constructor(private userService: UserService) {}
+
+  deleteUser() {
+    this.userService.deleteUser();
+  }
 
   ngOnInit(): void {}
 }

--- a/src/app/shered/settings-bottom-sheet/settings-bottom-sheet.component.html
+++ b/src/app/shered/settings-bottom-sheet/settings-bottom-sheet.component.html
@@ -22,7 +22,9 @@
         href="mailto:diary.for.reader@gmail.com"
         target="_blank"
         rel="noopener noreferrer"
-        ><mat-icon class="contents__icon">mail_outline</mat-icon>お問い合わせ</a
+        ><mat-icon class="contents__icon material-icons-rounded"
+          >open_in_new</mat-icon
+        >お問い合わせメールを送る</a
       >
     </li>
     <li class="contents__item">
@@ -30,7 +32,8 @@
         href="https://twitter.com/yuki_kouno_jp"
         target="_blank"
         rel="noopener noreferrer"
-        ><mat-icon class="contents__icon">perm_identity</mat-icon>開発者</a
+        ><mat-icon class="contents__icon">perm_identity</mat-icon
+        >開発者twitter</a
       >
     </li>
     <li class="contents__item">
@@ -41,8 +44,7 @@
     <mat-divider></mat-divider>
     <li class="contents__item">
       <a (click)="openDialog()"
-        ><mat-icon class="contents__icon">system_update</mat-icon
-        >アカウント管理</a
+        ><mat-icon class="contents__icon">system_update</mat-icon>退会する</a
       >
     </li>
   </ul>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -72,15 +72,14 @@ h2 {
 .login__item {
   border-radius: 50px !important;
 }
-.cdk-overlay-dark-backdrop {
-  background: inherit;
-}
 .mat-dialog-container {
-  backdrop-filter: blur(2px);
-  -webkit-backdrop-filter: blur(2px);
+  backdrop-filter: blur(40px);
+  -webkit-backdrop-filter: blur(40px);
   border-radius: 10px !important;
-  box-shadow: none;
-  background-color: rgba(255, 255, 255, 0.548);
+  box-shadow: 10px 10px 10px rgba(48, 48, 56, 0.02);
+  background-color: rgba(255, 255, 255, 0.5);
+  border: solid 2px transparent;
+  background-clip: padding-box;
 }
 .wrap-gradient {
   background: linear-gradient(135deg, #ffffff80, #ffffff00);


### PR DESCRIPTION
#142 
## 実装SS
### ダイアログ視認性改善前
![image](https://user-images.githubusercontent.com/57104153/104148598-3e874c00-5416-11eb-8469-70f07dd4d933.png)
### ダイアログ視認性改善後
![image](https://user-images.githubusercontent.com/57104153/104148256-e734ac00-5414-11eb-9c69-da3d2ed36d06.png)
### settings修正後
![image](https://user-images.githubusercontent.com/57104153/104148295-0df2e280-5415-11eb-8e1c-3a7dd6c009d2.png)

## 実装内容
- お問い合わせを押すとメールが開くことがわかるようにする
- 開発者を開発者twitterへ変更
- アカウント管理を退会するに変更
- 退会用ダイアログでの退会機能追加
- ダイアログの視認性改善

以上、修正しました。確認お願いします。