### PR TITLE
fix(nav): ナビゲーションボタンのマークアップ修正完了

### DIFF
--- a/src/app/bottom-nav/bottom-nav.component.html
+++ b/src/app/bottom-nav/bottom-nav.component.html
@@ -30,7 +30,7 @@
   <li class="item">
     <a class="item__btn" (click)="openBottomSheet()"
       ><mat-icon class="item__icon">more_horiz</mat-icon>
-      <p class="item__title">設定</p></a
+      <p class="item__title">その他</p></a
     >
   </li>
 </ul>

--- a/src/app/bottom-nav/bottom-nav.component.html
+++ b/src/app/bottom-nav/bottom-nav.component.html
@@ -1,27 +1,36 @@
 <ul class="nav">
-  <li>
-    <a routerLink="/"
-      ><mat-icon class="icon material-icons-outlined"
+  <li class="item">
+    <a class="item__btn" routerLink="/"
+      ><mat-icon class="item__icon material-icons-outlined"
         >import_contacts</mat-icon
-      ></a
+      >
+      <p class="item__title">ライブラリ</p></a
     >
   </li>
-  <li>
-    <a routerLink="/add-books"><mat-icon class="icon">search</mat-icon></a>
-  </li>
-  <li>
-    <a routerLink="/books-ranking"
-      ><mat-icon class="icon">format_list_numbered</mat-icon></a
+  <li class="item">
+    <a class="item__btn" routerLink="/calendar"
+      ><mat-icon class="item__icon material-icons-outlined"
+        >date_range</mat-icon
+      >
+      <p class="item__title">カレンダー</p></a
     >
   </li>
-  <li>
-    <a routerLink="/calendar"
-      ><mat-icon class="icon material-icons-outlined">date_range</mat-icon></a
+  <li class="item">
+    <a class="item__btn" routerLink="/add-books"
+      ><mat-icon class="item__icon material-icons-rounded">add</mat-icon>
+      <p class="item__title">本を追加</p></a
     >
   </li>
-  <li>
-    <a (click)="openBottomSheet()"
-      ><mat-icon class="icon">more_horiz</mat-icon></a
+  <li class="item">
+    <a class="item__btn" routerLink="/books-ranking"
+      ><mat-icon class="item__icon">format_list_numbered</mat-icon>
+      <p class="item__title">ランキング</p></a
+    >
+  </li>
+  <li class="item">
+    <a class="item__btn" (click)="openBottomSheet()"
+      ><mat-icon class="item__icon">more_horiz</mat-icon>
+      <p class="item__title">設定</p></a
     >
   </li>
 </ul>

--- a/src/app/bottom-nav/bottom-nav.component.scss
+++ b/src/app/bottom-nav/bottom-nav.component.scss
@@ -8,9 +8,11 @@
   display: flex;
   justify-content: space-around;
   align-items: center;
-  background: rgba(255, 255, 255, 0.3);
-  backdrop-filter: blur(6px);
-  -webkit-backdrop-filter: blur(6px);
+  backdrop-filter: blur(40px);
+  -webkit-backdrop-filter: blur(40px);
+  background-color: rgba(255, 255, 255, 0.4);
+  border: solid 2px transparent;
+  background-clip: padding-box;
   bottom: 0;
   left: 0;
   right: 0;
@@ -19,10 +21,23 @@
     display: none;
   }
 }
-.icon {
-  color: $sub-icon;
-  opacity: 0.5;
+.item {
+  width: 20%;
+  text-align: center;
+  &__title {
+    font-size: 10px;
+    font-weight: bold;
+    color: #909090;
+  }
+  &__icon {
+    color: #909090;
+  }
   &:hover {
-    color: mat-color($primary);
+    .item__title {
+      color: mat-color($primary);
+    }
+    .item__icon {
+      color: mat-color($primary);
+    }
   }
 }

--- a/src/app/shell/shell.module.ts
+++ b/src/app/shell/shell.module.ts
@@ -8,6 +8,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { SheredModule } from '../shered/shered.module';
 import { SideNavComponent } from '../side-nav/side-nav.component';
 import { MatButtonModule } from '@angular/material/button';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 @NgModule({
   declarations: [ShellComponent, BottomNavComponent, SideNavComponent],
@@ -17,6 +18,7 @@ import { MatButtonModule } from '@angular/material/button';
     MatIconModule,
     SheredModule,
     MatButtonModule,
+    MatTooltipModule,
   ],
   entryComponents: [BottomNavComponent],
   bootstrap: [ShellComponent],

--- a/src/app/shered/delete-user-dialog/delete-user-dialog.component.scss
+++ b/src/app/shered/delete-user-dialog/delete-user-dialog.component.scss
@@ -28,6 +28,5 @@
   }
   &__btn {
     color: white;
-    margin-right: 24px;
   }
 }

--- a/src/app/side-nav/side-nav.component.html
+++ b/src/app/side-nav/side-nav.component.html
@@ -52,7 +52,7 @@
   <li class="item">
     <a
       mat-fab
-      matTooltip="設定"
+      matTooltip="その他"
       matTooltipPosition="right"
       matTooltipClass="tooltip"
       class="item__btn wrap-gradient"

--- a/src/app/side-nav/side-nav.component.html
+++ b/src/app/side-nav/side-nav.component.html
@@ -1,34 +1,64 @@
 <ul class="nav">
   <li class="item">
-    <a mat-fab class="item__btn wrap-gradient" routerLink="/">
+    <a
+      mat-fab
+      matTooltip="ライブラリ"
+      matTooltipPosition="right"
+      matTooltipClass="tooltip"
+      class="item__btn wrap-gradient"
+      routerLink="/"
+    >
       <mat-icon class="item__icon material-icons-outlined"
         >import_contacts</mat-icon
       >
-      <p>ライブラリ</p>
     </a>
   </li>
   <li class="item">
-    <a mat-fab class="item__btn wrap-gradient" routerLink="/calendar">
+    <a
+      mat-fab
+      matTooltip="カレンダー"
+      matTooltipPosition="right"
+      matTooltipClass="tooltip"
+      class="item__btn wrap-gradient"
+      routerLink="/calendar"
+    >
       <mat-icon class="item__icon material-icons-outlined">date_range</mat-icon>
-      <p>カレンダー</p>
     </a>
   </li>
   <li class="item">
-    <a mat-fab class="item__btn wrap-gradient" routerLink="/add-books">
+    <a
+      mat-fab
+      matTooltip="本を追加"
+      matTooltipPosition="right"
+      matTooltipClass="tooltip"
+      class="item__btn wrap-gradient"
+      routerLink="/add-books"
+    >
       <mat-icon class="item__icon material-icons-rounded">add</mat-icon>
-      <p>本を追加</p>
     </a>
   </li>
   <li class="item">
-    <a mat-fab class="item__btn wrap-gradient" routerLink="/books-ranking">
+    <a
+      mat-fab
+      matTooltip="ランキング"
+      matTooltipPosition="right"
+      matTooltipClass="tooltip"
+      class="item__btn wrap-gradient"
+      routerLink="/books-ranking"
+    >
       <mat-icon class="item__icon">format_list_numbered</mat-icon>
-      <p>カレンダー</p>
     </a>
   </li>
   <li class="item">
-    <a mat-fab class="item__btn wrap-gradient" (click)="openSheet()">
+    <a
+      mat-fab
+      matTooltip="設定"
+      matTooltipPosition="right"
+      matTooltipClass="tooltip"
+      class="item__btn wrap-gradient"
+      (click)="openSheet()"
+    >
       <mat-icon class="item__icon">more_horiz</mat-icon>
-      <p>設定</p>
     </a>
   </li>
 </ul>

--- a/src/app/side-nav/side-nav.component.html
+++ b/src/app/side-nav/side-nav.component.html
@@ -1,29 +1,34 @@
 <ul class="nav">
   <li class="item">
-    <button mat-fab class="item__btn wrap-gradient" routerLink="/">
+    <a mat-fab class="item__btn wrap-gradient" routerLink="/">
       <mat-icon class="item__icon material-icons-outlined"
         >import_contacts</mat-icon
       >
-    </button>
+      <p>ライブラリ</p>
+    </a>
   </li>
   <li class="item">
-    <button mat-fab class="item__btn wrap-gradient" routerLink="/calendar">
+    <a mat-fab class="item__btn wrap-gradient" routerLink="/calendar">
       <mat-icon class="item__icon material-icons-outlined">date_range</mat-icon>
-    </button>
+      <p>カレンダー</p>
+    </a>
   </li>
   <li class="item">
-    <button mat-fab class="item__btn wrap-gradient" routerLink="/add-books">
+    <a mat-fab class="item__btn wrap-gradient" routerLink="/add-books">
       <mat-icon class="item__icon material-icons-rounded">add</mat-icon>
-    </button>
+      <p>本を追加</p>
+    </a>
   </li>
   <li class="item">
-    <button mat-fab class="item__btn wrap-gradient" routerLink="/books-ranking">
+    <a mat-fab class="item__btn wrap-gradient" routerLink="/books-ranking">
       <mat-icon class="item__icon">format_list_numbered</mat-icon>
-    </button>
+      <p>カレンダー</p>
+    </a>
   </li>
   <li class="item">
-    <button mat-fab class="item__btn wrap-gradient" (click)="openSheet()">
+    <a mat-fab class="item__btn wrap-gradient" (click)="openSheet()">
       <mat-icon class="item__icon">more_horiz</mat-icon>
-    </button>
+      <p>設定</p>
+    </a>
   </li>
 </ul>

--- a/src/app/side-nav/side-nav.component.scss
+++ b/src/app/side-nav/side-nav.component.scss
@@ -20,25 +20,15 @@
 .item {
   margin: 0 0 16px 16px;
   &__btn {
-    width: 70px;
-    height: 70px;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    font-size: 12px;
-    font-weight: bold;
-    color: #909090;
     background-color: rgba(214, 214, 214, 0.411);
     &:hover {
       transition: 0.3s;
-      color: mat-color($primary);
       box-shadow: 4px 10px 10px #5e5e5e6e,
         inset 6px 6px 10px rgba(255, 255, 255, 0.671),
         inset -3px -1px 10px rgba(126, 126, 126, 0.2);
       .item__icon {
-        color: mat-color($primary);
         transition: 0.3s;
+        color: mat-color($primary);
       }
     }
   }

--- a/src/app/side-nav/side-nav.component.scss
+++ b/src/app/side-nav/side-nav.component.scss
@@ -20,15 +20,29 @@
 .item {
   margin: 0 0 16px 16px;
   &__btn {
+    width: 70px;
+    height: 70px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    font-size: 12px;
+    font-weight: bold;
+    color: #909090;
     background-color: rgba(214, 214, 214, 0.411);
     &:hover {
+      transition: 0.3s;
+      color: mat-color($primary);
+      box-shadow: 4px 10px 10px #5e5e5e6e,
+        inset 6px 6px 10px rgba(255, 255, 255, 0.671),
+        inset -3px -1px 10px rgba(126, 126, 126, 0.2);
       .item__icon {
         color: mat-color($primary);
+        transition: 0.3s;
       }
     }
   }
   &__icon {
-    color: $sub-icon;
-    opacity: 0.3;
+    color: #909090;
   }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -169,3 +169,8 @@ h2 {
 .mat-tab-header-pagination-chevron {
   border-color: #808080;
 }
+.tooltip {
+  background-color: rgb(240, 240, 240);
+  color: mat-color($primary) !important;
+  font-weight: bold;
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -93,9 +93,11 @@ h2 {
   box-shadow: 3px 6px 10px -1px rgba(0, 132, 255, 0.5);
 }
 .mat-bottom-sheet-container {
-  backdrop-filter: blur(3px);
-  -webkit-backdrop-filter: blur(3px);
-  background-color: rgba(240, 240, 240, 0.8);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  background-color: rgba(255, 255, 255, 0.8);
+  border: solid 2px transparent;
+  background-clip: padding-box;
 }
 .custom-bottom-nav {
   height: 80vh;


### PR DESCRIPTION
#139 

### side nav
![image](https://user-images.githubusercontent.com/57104153/104345479-bef69b80-5541-11eb-8800-1eac3fab9906.png)
### bottom nav
![image](https://user-images.githubusercontent.com/57104153/104337845-425fbf00-5539-11eb-9dc9-176b94a3740e.png)
### margin-right 削除部
![image](https://user-images.githubusercontent.com/57104153/104337969-5d323380-5539-11eb-9706-a70e5beca7eb.png)


## 実装内容
- ナビゲーションボタンにタイトル表示
- icon変更
- 消し忘れのmargin-right削除

以上、実装しました。確認お願いします。
