### PR TITLE
fix(ランキング画面): マークアップ修正

### DIFF
--- a/src/app/books-ranking/books-ranking/books-ranking.component.html
+++ b/src/app/books-ranking/books-ranking/books-ranking.component.html
@@ -3,7 +3,7 @@
     <img src="/assets/images/brand.png" alt="brand.logo" class="logo__sp" />
     <img
       src="/assets/images/brand-title.logo.png"
-      alt="brand.logo"
+      alt="読書家のための日記帳"
       class="logo__tab"
     />
   </a>

--- a/src/app/books-ranking/books-ranking/books-ranking.component.html
+++ b/src/app/books-ranking/books-ranking/books-ranking.component.html
@@ -1,6 +1,10 @@
 <header>
   <a class="logo" routerLink="/">
-    <img src="/assets/images/brand.png" alt="brand.logo" class="logo__sp" />
+    <img
+      src="/assets/images/brand.png"
+      alt="読書家のための日記帳"
+      class="logo__sp"
+    />
     <img
       src="/assets/images/brand-title.logo.png"
       alt="読書家のための日記帳"

--- a/src/app/books-ranking/books-ranking/books-ranking.component.html
+++ b/src/app/books-ranking/books-ranking/books-ranking.component.html
@@ -1,15 +1,18 @@
 <header>
-  <div class="logo">
-    <img src="assets/images/brand.png" alt="brand.logo" class="logo__sp" />
+  <a class="logo" routerLink="/">
+    <img src="/assets/images/brand.png" alt="brand.logo" class="logo__sp" />
     <img
-      src="assets/images/brand-title.png"
+      src="/assets/images/brand-title.logo.png"
       alt="brand.logo"
       class="logo__tab"
     />
-  </div>
+  </a>
   <h2 class="title">Book Ranking</h2>
 </header>
 <div class="container">
+  <p class="description">
+    Amazon.co.jpの売れ筋ランキング。ランキングは1時間ごとに更新されます。
+  </p>
   <mat-tab-group>
     <mat-tab label="総合">
       <div class="grid">

--- a/src/app/books-ranking/books-ranking/books-ranking.component.scss
+++ b/src/app/books-ranking/books-ranking/books-ranking.component.scss
@@ -2,36 +2,54 @@
 @import 'material-custom';
 
 header {
-  height: 60px;
+  height: 48px;
   width: 100%;
   position: fixed;
   z-index: 1000;
   text-align: center;
+  backdrop-filter: blur(40px);
+  -webkit-backdrop-filter: blur(40px);
+  background-color: rgba(255, 255, 255, 0.3);
+  border-bottom: solid 2px transparent;
+  background-clip: padding-box;
+  @include tab-header {
+    height: 60px;
+  }
 }
 .logo {
   position: absolute;
-  top: 6px;
+  top: 0;
   left: 16px;
   &__sp {
     height: 48px;
-    @include tab {
+    @include tab-header {
       display: none;
     }
   }
   &__tab {
     height: 60px;
-    @include sp {
+    @include sp-header {
       display: none;
     }
   }
 }
 .title {
-  line-height: 70px;
+  line-height: 48px;
+  @include tab {
+    height: 60px;
+  }
 }
 .container {
-  padding: 70px 16px;
+  padding: 50px 16px;
   @include tab {
     padding: 70px 160px;
+  }
+}
+.description {
+  font-size: 12px;
+  color: #909090;
+  @include tab-header {
+    text-align: right;
   }
 }
 .grid {

--- a/src/app/books-ranking/books-ranking/books-ranking.component.ts
+++ b/src/app/books-ranking/books-ranking/books-ranking.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { Observable } from 'rxjs';
 import { DatabaseRankingBooksService } from 'src/app/services/database-ranking-books.service';
 import { RankingBooksInfo } from 'src/app/interface/ranking-books-info';
+import { SeoService } from 'src/app/services/seo.service';
 
 @Component({
   selector: 'app-books-ranking',
@@ -28,7 +29,12 @@ export class BooksRankingComponent implements OnInit {
     RankingBooksInfo[]
   > = this.rankingBookService.getHobbiesRanking();
 
-  constructor(private rankingBookService: DatabaseRankingBooksService) {}
+  constructor(
+    private rankingBookService: DatabaseRankingBooksService,
+    private seoService: SeoService
+  ) {
+    this.seoService.setTitleAndMeta('ブックランキング');
+  }
 
   ngOnInit(): void {}
 }

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -15,3 +15,15 @@
     @content;
   }
 }
+
+@mixin sp-header {
+  @media (max-width: 820px) {
+    @content;
+  }
+}
+
+@mixin tab-header {
+  @media (min-width: 821px) {
+    @content;
+  }
+}


### PR DESCRIPTION
## 実装内容

- headerにbackground-colorつける
- ロゴにリンクをつける
- いつ、どこ、何順、のランキングか表示

以上、実装しました。確認お願いします。

## 残りタスク(テスト後)
- mat-tag-groupのpaginationのカスタマイズ（押しても意味のない時は消すか、disableカラーにする）