### PR TITLE
feat(ランキング): amazon詳細ページリンク追加 fix #164

### DIFF
--- a/src/app/books-ranking/ranking/ranking.component.html
+++ b/src/app/books-ranking/ranking/ranking.component.html
@@ -1,8 +1,10 @@
 <div class="book">
   <p class="book__id">{{ rankingIndex + 1 }}</p>
-  <figure class="book__thumb">
-    <img class="book__img" [src]="book.img" alt="" />
-  </figure>
-  <p class="book__title">{{ book.title }}</p>
-  <p class="book__author">{{ book.author }}</p>
+  <a [href]="book.link" target="brank">
+    <figure class="book__thumb">
+      <img class="book__img" [src]="book.img" alt="" />
+    </figure>
+    <p class="book__title">{{ book.title }}</p>
+    <p class="book__author">{{ book.author }}</p>
+  </a>
 </div>

--- a/src/app/interface/ranking-book.ts
+++ b/src/app/interface/ranking-book.ts
@@ -4,6 +4,7 @@ export interface RankingBook {
       title: string;
       img: string;
       author: string;
+      link: string;
     }
   ];
 }

--- a/src/app/interface/ranking-books-info.ts
+++ b/src/app/interface/ranking-books-info.ts
@@ -2,4 +2,5 @@ export interface RankingBooksInfo {
   title: string;
   img: string;
   author: string;
+  link: string;
 }


### PR DESCRIPTION
#164 
## 実装内容
-  本のランキング一覧にamazonの対象製品ページリンクを追加

以上、実装しました。確認お願いします。